### PR TITLE
Update sqlboiler(v3.6.1 -> v4.1.2), sqlboiler-crdb

### DIFF
--- a/poseidon/golang/Dockerfile
+++ b/poseidon/golang/Dockerfile
@@ -25,6 +25,7 @@ ENV PROTOC_GRPC_WEB_VER 1.0.7
 
 ENV BINDATA_VER v3.16.0
 ENV SQLBOILER_VER v4.1.2
+ENV SQLBOILER_CRDB_COMMIT_ID d540ee5
 
 ENV COCKROACH_DB_VER v19.2.0
 ENV GOMIGRATE_VER v4.8.0
@@ -52,7 +53,7 @@ RUN apt-get update && \
     mv migrate.linux-amd64 /usr/local/bin/migrate && \
     GO111MODULE=on go get -u github.com/kevinburke/go-bindata/...@$BINDATA_VER && \
     GO111MODULE=on go get -u github.com/volatiletech/sqlboiler/v4@$SQLBOILER_VER && \
-    GO111MODULE=on go get -u github.com/glerchundi/sqlboiler-crdb/v4 && \
+    GO111MODULE=on go get -u github.com/glerchundi/sqlboiler-crdb/v4@$SQLBOILER_CRDB_COMMIT_ID && \
     wget -nv https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOC_VER/protoc-$PROTOC_VER-linux-x86_64.zip && \
     unzip protoc-$PROTOC_VER-linux-x86_64.zip bin/protoc -d protoc && \
     mv protoc/bin/protoc /usr/local/bin && \

--- a/poseidon/golang/Dockerfile
+++ b/poseidon/golang/Dockerfile
@@ -24,8 +24,7 @@ ENV PROTOC_GO_GEN_VER v1.3.2
 ENV PROTOC_GRPC_WEB_VER 1.0.7
 
 ENV BINDATA_VER v3.16.0
-ENV SQLBOILER_VER v3.6.1
-ENV SQLBOILER_CRDB_COMMIT db3049d
+ENV SQLBOILER_VER v4.1.2
 
 ENV COCKROACH_DB_VER v19.2.0
 ENV GOMIGRATE_VER v4.8.0
@@ -52,8 +51,8 @@ RUN apt-get update && \
     wget -nv -O- https://github.com/golang-migrate/migrate/releases/download/$GOMIGRATE_VER/migrate.linux-amd64.tar.gz | tar xvz && \
     mv migrate.linux-amd64 /usr/local/bin/migrate && \
     GO111MODULE=on go get -u github.com/kevinburke/go-bindata/...@$BINDATA_VER && \
-    GO111MODULE=on go get -u github.com/volatiletech/sqlboiler@$SQLBOILER_VER && \
-    GO111MODULE=on go get -u github.com/glerchundi/sqlboiler-crdb@$SQLBOILER_CRDB_COMMIT && \
+    GO111MODULE=on go get -u github.com/volatiletech/sqlboiler/v4@$SQLBOILER_VER && \
+    GO111MODULE=on go get -u github.com/glerchundi/sqlboiler-crdb/v4 && \
     wget -nv https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOC_VER/protoc-$PROTOC_VER-linux-x86_64.zip && \
     unzip protoc-$PROTOC_VER-linux-x86_64.zip bin/protoc -d protoc && \
     mv protoc/bin/protoc /usr/local/bin && \


### PR DESCRIPTION
This PR updates the version of sqlboiler ( from v3.6.1 -> v4.1.2). Along with sqlboiler, sqlboiler-crdb's module name has also be changed to [github.com/glerchundi/sqlboiler-crdb/v4](github.com/glerchundi/sqlboiler-crdb/v4)